### PR TITLE
Split layout into three columns

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -68,7 +68,7 @@ body {
 /* Main layout */
 .app-main {
   display: grid;
-  grid-template-columns: minmax(320px, 1fr) 380px;
+  grid-template-columns: minmax(260px, 1fr) minmax(260px, 1fr) 380px;
   gap: 2rem;
   padding: 2rem;
 }
@@ -86,7 +86,6 @@ body {
   background: var(--secondary-color);
   padding: 2rem;
   border-radius: var(--border-radius);
-  margin-bottom: 2rem;
 }
 
 .config-form h2 {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,20 +73,22 @@ function App() {
         </header>
 
         <main className="app-main">
-          <div className="generator-section">
+          <section className="params-section">
             <NameConfigForm
               config={config}
               onConfigChange={setConfig}
               onGenerate={handleGenerate}
               isGenerating={isGenerating}
             />
-            
+          </section>
+
+          <section className="names-section">
             <GeneratedNames
               generatedNames={generatedNames}
               onSelectName={handleSelectName}
               error={error}
             />
-          </div>
+          </section>
 
           <aside className="history-section">
             <UsedNamesHistory


### PR DESCRIPTION
## Summary
- reorganize App.tsx sections into params, names, history
- tweak grid layout to use three columns
- remove extra margin from the config form

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e5cb099208330be95e5fb4daca386